### PR TITLE
Enable go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/agext/levenshtein


### PR DESCRIPTION
Go modules are becoming a de-facto standard in the Go community and adding `go.mod` files with metadata helps projects which may consume this repository as a dependency in deciding how to pin transitive dependencies and how to resolve conflicts.

This is a result of the following commands:

```
go mod init
go get ./...
go mod tidy
```

in a clean Go `1.11.5` environment.